### PR TITLE
refactor(complaints): extrai lógica de fetch para hook customizado

### DIFF
--- a/context/ComplaintsContext.jsx
+++ b/context/ComplaintsContext.jsx
@@ -1,36 +1,20 @@
 // context/ComplaintsContext.jsx
-import { getComplaints } from '@/services/complaints.service';
-import { createContext, useCallback, useContext, useEffect, useState } from 'react';
+import { useComplaintsFetch } from '@/hooks/useComplaintsFetch';
+import { createContext, useContext, useEffect } from 'react';
 
 const ComplaintsContext = createContext(null);
 
 export function ComplaintsProvider({ children }) {
-  const [data, setData] = useState([]);
-  const [loading, setLoading] = useState(true);
-  const [refreshing, setRefreshing] = useState(false);
-  const [error, setError] = useState(null);
-
-  const fetchComplaints = useCallback(async (signal, options = {}) => {
-    const { silent = false } = options;
-
-    try {
-      if (!silent) {
-        setLoading(true);
-      }
-      setError(null);
-      const result = await getComplaints(signal);
-
-      setData(result);
-    } catch (err) {
-      if (err.name === 'AbortError') return;
-      setError(err.message ?? 'Erro ao carregar denúncias');
-    } finally {
-      if (!silent) {
-        setLoading(false);
-      }
-      setRefreshing(false);
-    }
-  }, []);
+  const {
+    data,
+    loading,
+    refreshing,
+    error,
+    fetchComplaints,
+    refresh,
+    refetchSilent,
+    refetch,
+  } = useComplaintsFetch();
 
   useEffect(() => {
     if (typeof AbortController !== 'undefined') {
@@ -39,34 +23,6 @@ export function ComplaintsProvider({ children }) {
       return () => controller.abort();
     } else {
       fetchComplaints();
-    }
-  }, [fetchComplaints]);
-
-  const refresh = useCallback(async () => {
-    setRefreshing(true);
-    if (typeof AbortController !== 'undefined') {
-      const controller = new AbortController();
-      await fetchComplaints(controller.signal, { silent: true });
-    } else {
-      await fetchComplaints(undefined, { silent: true });
-    }
-  }, [fetchComplaints]);
-
-  const refetchSilent = useCallback(async () => {
-    if (typeof AbortController !== 'undefined') {
-      const controller = new AbortController();
-      await fetchComplaints(controller.signal, { silent: true });
-    } else {
-      await fetchComplaints(undefined, { silent: true });
-    }
-  }, [fetchComplaints]);
-
-  const refetch = useCallback(async () => {
-    if (typeof AbortController !== 'undefined') {
-      const controller = new AbortController();
-      await fetchComplaints(controller.signal);
-    } else {
-      await fetchComplaints();
     }
   }, [fetchComplaints]);
 

--- a/hooks/useComplaintsFetch.jsx
+++ b/hooks/useComplaintsFetch.jsx
@@ -1,0 +1,72 @@
+// hooks/useComplaintsFetch.jsx
+import { getComplaints } from '@/services/complaints.service';
+import { useCallback, useState } from 'react';
+
+export function useComplaintsFetch() {
+  const [data, setData] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [error, setError] = useState(null);
+
+  const fetchComplaints = useCallback(async (signal, options = {}) => {
+    const { silent = false } = options;
+
+    try {
+      if (!silent) {
+        setLoading(true);
+      }
+      setError(null);
+      const result = await getComplaints(signal);
+
+      setData(result);
+    } catch (err) {
+      if (err.name === 'AbortError') return;
+      setError(err.message ?? 'Erro ao carregar denúncias');
+    } finally {
+      if (!silent) {
+        setLoading(false);
+      }
+      setRefreshing(false);
+    }
+  }, []);
+
+  const executeWithAbortController = useCallback(
+    async (callback) => {
+      if (typeof AbortController !== 'undefined') {
+        const controller = new AbortController();
+        await callback(controller.signal);
+      } else {
+        await callback();
+      }
+    },
+    []
+  );
+
+  const refresh = useCallback(async () => {
+    setRefreshing(true);
+    await executeWithAbortController((signal) =>
+      fetchComplaints(signal, { silent: true })
+    );
+  }, [executeWithAbortController, fetchComplaints]);
+
+  const refetchSilent = useCallback(async () => {
+    await executeWithAbortController((signal) =>
+      fetchComplaints(signal, { silent: true })
+    );
+  }, [executeWithAbortController, fetchComplaints]);
+
+  const refetch = useCallback(async () => {
+    await executeWithAbortController((signal) => fetchComplaints(signal));
+  }, [executeWithAbortController, fetchComplaints]);
+
+  return {
+    data,
+    loading,
+    refreshing,
+    error,
+    fetchComplaints,
+    refresh,
+    refetchSilent,
+    refetch,
+  };
+}


### PR DESCRIPTION
## O que foi feito

Refatorado o ComplaintsContext para melhorar a organização e manutençao do código, extraindo toda a lógica de fetch de denúncias para um hook customizado reutilizável.

## Mudanças
- Criado novo hook `useComplaintsFetch.jsx` com toda lógica de fetch e estado
- Melhorada separação de responsabilidades (Context apenas gerencia contexto, hook gerencia fetch)
- Mantida exatamente a mesma funcionalidade