### PR TITLE
Adiciona Husky e lint-staged para padronização de código

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "android": "expo start --android",
     "ios": "expo start --ios",
     "web": "expo start --web",
-    "lint": "expo lint"
+    "lint": "expo lint",
+    "prepare": "husky"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
@@ -45,7 +46,14 @@
     "eslint": "^9.25.0",
     "eslint-config-expo": "~10.0.0",
     "eslint-import-resolver-alias": "^1.1.2",
+    "husky": "^9.1.7",
+    "lint-staged": "^16.4.0",
     "typescript": "~5.9.2"
+  },
+  "lint-staged": {
+    "*.{js,jsx,ts,tsx}": [
+      "eslint --fix"
+    ]
   },
   "private": true
 }


### PR DESCRIPTION
## O que foi feito

Adicionada configuração de padronização automática de código usando Husky e lint-staged para garantir qualidade e consistência do código em todos os commits.

## Mudanças
- Instalado Husky v9.1.7 para gerenciamento de Git hooks
- Instalado lint-staged v16.4.0 para executar linters em arquivos staged
- Configurado hook pre-commit para executar eslint --fix automaticamente em arquivos JS/TS
- Adicionada configuração lint-staged no package.json