### PR TITLE
fix: corrigir envio de múltiplas fotos na criação de denúncia

### DIFF
--- a/app/complaint/create.jsx
+++ b/app/complaint/create.jsx
@@ -271,7 +271,7 @@ const styles = StyleSheet.create({
     position: 'absolute',
     left: 0,
     right: 0,
-    bottom: 0,
+    bottom: 20,
     padding: 16,
     backgroundColor: COLORS.background,
     borderTopWidth: 1,

--- a/services/complaints.service.jsx
+++ b/services/complaints.service.jsx
@@ -22,15 +22,15 @@ export async function createComplaint(data) {
   formData.append('location', JSON.stringify(data.location));
 
   //  MULTIPLAS FOTOS
-  if (data.imageUris && data.imageUris.length > 0) {
-    data.imageUris.forEach((uri, index) => {
-      formData.append('photos', {
-        uri,
-        name: `foto_${index}.jpg`,
-        type: 'image/jpeg',
-      });
-    });
-  }
+  data.photos.forEach((uri, index) => {
+  const fixedUri = uri.startsWith('file://') ? uri : 'file://' + uri;
+
+  formData.append('photos', {
+    uri: fixedUri,
+    name: `foto_${index}.jpg`,
+    type: 'image/jpeg',
+  });
+});
 
   return apiFetch('/complaints', {
     method: 'POST',


### PR DESCRIPTION
Correção no envio de fotos na criação de denúncia.

- Ajustado nome do campo de imageUris para photos no service
- Corrigido envio de múltiplas imagens via FormData
- Garantido compatibilidade com multer no backend

Agora as fotos estão sendo corretamente enviadas e salvas no servidor.