### PR TITLE
fix: convert images to jpeg before upload

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "expo-font": "~14.0.11",
     "expo-haptics": "~15.0.8",
     "expo-image": "~3.0.11",
+    "expo-image-manipulator": "~14.0.8",
     "expo-image-picker": "~17.0.10",
     "expo-linking": "~8.0.11",
     "expo-location": "~19.0.8",

--- a/services/complaints.service.jsx
+++ b/services/complaints.service.jsx
@@ -1,3 +1,4 @@
+import * as ImageManipulator from 'expo-image-manipulator';
 import { apiFetch } from './api';
 
 export async function getComplaints(signal) {
@@ -14,6 +15,7 @@ export async function getComplaints(signal) {
 export async function createComplaint(data) {
   const formData = new FormData();
 
+  // Campos básicos da denúncia
   formData.append('title', data.title);
   formData.append('description', data.description);
   formData.append('type', data.type);
@@ -21,20 +23,42 @@ export async function createComplaint(data) {
   formData.append('status', data.status);
   formData.append('location', JSON.stringify(data.location));
 
-  //  MULTIPLAS FOTOS
-  data.photos.forEach((uri, index) => {
-  const fixedUri = uri.startsWith('file://') ? uri : 'file://' + uri;
 
+ //  MULTIPLAS FOTOS
+for (let i = 0; i < data.photos.length; i++) {
+  const uri = data.photos[i];
+  // Converte imagem (resolve HEIC e outros formatos)
+  const convertedUri = await convertToJpg(uri);
+  // Corrige URI caso necessário
+  const fixedUri = convertedUri.startsWith('file://')
+    ? convertedUri
+    : 'file://' + convertedUri;
+  // Adiciona ao FormData
   formData.append('photos', {
     uri: fixedUri,
-    name: `foto_${index}.jpg`,
+    name: `foto_${i}.jpg`,
     type: 'image/jpeg',
   });
-});
-
+}
+  // Envia para API
   return apiFetch('/complaints', {
     method: 'POST',
     body: formData,
   });
 
+}
+
+//Converte qualquer imagem para formato JPEG. Isso é útil para garantir
+//  compatibilidade, especialmente com fotos tiradas em iPhones que podem estar no formato HEIC.
+async function convertToJpg(uri) {
+  const result = await ImageManipulator.manipulateAsync(
+    uri,
+    [],
+    {
+      compress: 1, // mantém qualidade máxima (pode ajustar depois)
+      format: ImageManipulator.SaveFormat.JPEG,
+    }
+  );
+
+  return result.uri;
 }


### PR DESCRIPTION
Adiciona conversão automática de imagens para JPEG antes do envio da denúncia, garantindo compatibilidade com imagens HEIC e mantendo o upload de múltiplas fotos.