### PR TITLE
Feature/implenta validators registro

### DIFF
--- a/components/auth/AuthInput.jsx
+++ b/components/auth/AuthInput.jsx
@@ -1,6 +1,7 @@
 import { View, Text, TextInput, Pressable } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import { authInputStyles as styles } from '@/styles/auth';
+import PasswordStrengthIndicator from './PasswordStrengthIndicator';
 
 export default function AuthInput({
   label,
@@ -14,6 +15,7 @@ export default function AuthInput({
   onToggleSecure,
   colors,
   isDark,
+  showPasswordStrength = false,
   ...props
 }) {
   return (
@@ -52,6 +54,9 @@ export default function AuthInput({
           </Pressable>
         )}
       </View>
+      {showPasswordStrength && !error && (
+        <PasswordStrengthIndicator password={value} colors={colors} isDark={isDark} />
+      )}
       {error && <Text style={[styles.errorText, { color: colors.danger }]}>{error}</Text>}
     </View>
   );

--- a/components/auth/PasswordStrengthIndicator.jsx
+++ b/components/auth/PasswordStrengthIndicator.jsx
@@ -1,0 +1,47 @@
+import { View, Text } from 'react-native';
+import { useEffect, useState } from 'react';
+import zxcvbn from 'zxcvbn';
+import { styles } from '@/styles/auth/password-strength-indicator.styles';
+
+const STRENGTH_CONFIG = {
+  0: { label: 'Muito fraca', color: '#EF4444', width: '20%' },
+  1: { label: 'Fraca', color: '#F97316', width: '40%' },
+  2: { label: 'Média', color: '#EAB308', width: '60%' },
+  3: { label: 'Forte', color: '#22C55E', width: '80%' },
+  4: { label: 'Muito forte', color: '#10B981', width: '100%' },
+};
+
+export default function PasswordStrengthIndicator({ password, colors, isDark }) {
+  const [strength, setStrength] = useState(null);
+
+  useEffect(() => {
+    if (!password || password.length === 0) {
+      setStrength(null);
+      return;
+    }
+
+    const result = zxcvbn(password);
+    setStrength(result.score);
+  }, [password]);
+
+  if (strength === null) return null;
+
+  const config = STRENGTH_CONFIG[strength];
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.barContainer}>
+        <View
+          style={[
+            styles.bar,
+            {
+              backgroundColor: config.color,
+              width: config.width,
+            },
+          ]}
+        />
+      </View>
+      <Text style={[styles.label, { color: config.color }]}>{config.label}</Text>
+    </View>
+  );
+}

--- a/components/auth/RegisterForm.jsx
+++ b/components/auth/RegisterForm.jsx
@@ -66,7 +66,7 @@ export default function RegisterForm({
         label="SENHA"
         value={form.password}
         onChangeText={(value) => updateField('password', value)}
-        placeholder="Mínimo 6 caracteres"
+        placeholder="Mínimo 8 caracteres"
         iconName="lock-closed-outline"
         error={errors.password}
         colors={colors}

--- a/components/auth/RegisterForm.jsx
+++ b/components/auth/RegisterForm.jsx
@@ -74,6 +74,7 @@ export default function RegisterForm({
         secureTextEntry={!showPassword}
         showToggle
         onToggleSecure={() => setShowPassword(!showPassword)}
+        showPasswordStrength
         autoCapitalize="none"
         autoCorrect={false}
         editable={!isSubmitting}

--- a/constants/error.messages.constants.jsx
+++ b/constants/error.messages.constants.jsx
@@ -1,0 +1,23 @@
+export const AUTH_ERRORS = {
+  NAME_REQUIRED: 'Nome é obrigatório',
+  NAME_MIN_LENGTH: 'Nome deve ter pelo menos 2 caracteres',
+
+  EMAIL_REQUIRED: 'Email é obrigatório',
+  EMAIL_INVALID: 'Email inválido',
+
+  USERNAME_REQUIRED: 'Username é obrigatório',
+  USERNAME_MIN_LENGTH: 'Username deve ter pelo menos 4 caracteres',
+  USERNAME_INVALID: 'Username pode conter apenas letras, números e _',
+
+  PASSWORD_REQUIRED: 'Senha é obrigatória',
+  PASSWORD_MIN_LENGTH: 'Senha deve ter pelo menos 8 caracteres',
+  PASSWORD_WEAK: 'Senha deve conter letras maiúsculas, minúsculas e números',
+
+  CONFIRM_PASSWORD_REQUIRED: 'Confirme sua senha',
+  PASSWORDS_DONT_MATCH: 'Senhas não coincidem',
+
+  EMAIL_ALREADY_IN_USE: 'Este email já está cadastrado',
+  USERNAME_ALREADY_EXISTS: 'Este username já está em uso',
+  WEAK_PASSWORD: 'Senha muito fraca',
+  GENERIC_ERROR: 'Não foi possível criar conta. Tente novamente.',
+};

--- a/hooks/useAuthForm.jsx
+++ b/hooks/useAuthForm.jsx
@@ -1,7 +1,9 @@
+import { AUTH_ERRORS } from '@/constants/error.messages.constants';
+import { register } from '@/services/auth.service';
+import { validateForm as validateFormSchema } from '@/validators/auth.validators';
+import { router } from 'expo-router';
 import { useState } from 'react';
 import { Alert } from 'react-native';
-import { router } from 'expo-router';
-import { register } from '@/services/auth.service';
 
 export function useAuthForm() {
   const [form, setForm] = useState({
@@ -20,52 +22,21 @@ export function useAuthForm() {
   const updateField = (field, value) => {
     setForm((prev) => ({ ...prev, [field]: value }));
     if (errors[field]) {
-      setErrors((prev) => ({ ...prev, [field]: null }));
+      const newErrors = { ...errors };
+      delete newErrors[field];
+      setErrors(newErrors);
     }
   };
 
   const validateForm = () => {
-    const newErrors = {};
-
-    if (!form.name.trim()) {
-      newErrors.name = 'Nome é obrigatório';
-    } else if (form.name.trim().length < 3) {
-      newErrors.name = 'Nome deve ter pelo menos 3 caracteres';
-    }
-
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!form.email.trim()) {
-      newErrors.email = 'Email é obrigatório';
-    } else if (!emailRegex.test(form.email)) {
-      newErrors.email = 'Email inválido';
-    }
-
-    if (!form.username.trim()) {
-      newErrors.username = 'Username é obrigatório';
-    } else if (form.username.trim().length < 3) {
-      newErrors.username = 'Username deve ter pelo menos 3 caracteres';
-    } else if (!/^[a-zA-Z0-9_]+$/.test(form.username)) {
-      newErrors.username = 'Username pode conter apenas letras, números e _';
-    }
-
-    if (!form.password) {
-      newErrors.password = 'Senha é obrigatória';
-    } else if (form.password.length < 6) {
-      newErrors.password = 'Senha deve ter pelo menos 6 caracteres';
-    }
-
-    if (!form.confirmPassword) {
-      newErrors.confirmPassword = 'Confirme sua senha';
-    } else if (form.password !== form.confirmPassword) {
-      newErrors.confirmPassword = 'Senhas não coincidem';
-    }
-
-    setErrors(newErrors);
-    return Object.keys(newErrors).length === 0;
+    const validationErrors = validateFormSchema(form);
+    setErrors(validationErrors);
+    return Object.keys(validationErrors).length === 0;
   };
 
   const handleSubmit = async () => {
-    if (!validateForm()) return;
+    const isValid = validateForm();
+    if (!isValid) return;
     if (isSubmitting) return;
 
     try {
@@ -85,21 +56,19 @@ export function useAuthForm() {
         },
       ]);
     } catch (error) {
-      console.error('Erro ao criar conta:', error);
-
-      let errorMessage = 'Não foi possível criar conta. Tente novamente.';
+      let errorMessage = AUTH_ERRORS.GENERIC_ERROR;
 
       if (error.code === 'auth/email-already-in-use') {
-        errorMessage = 'Este email já está cadastrado';
+        errorMessage = AUTH_ERRORS.EMAIL_ALREADY_IN_USE;
       } else if (error.code === 'auth/weak-password') {
-        errorMessage = 'Senha muito fraca';
+        errorMessage = AUTH_ERRORS.WEAK_PASSWORD;
       } else if (error.code === 'auth/invalid-email') {
-        errorMessage = 'Email inválido';
+        errorMessage = AUTH_ERRORS.EMAIL_INVALID;
       } else if (error.message === 'USERNAME_ALREADY_EXISTS') {
-        errorMessage = 'Este username já está em uso';
+        errorMessage = AUTH_ERRORS.USERNAME_ALREADY_EXISTS;
       }
 
-      Alert.alert('Erro', errorMessage);
+      console.error('Erro ao criar conta:', errorMessage, error);
     } finally {
       setIsSubmitting(false);
     }
@@ -111,7 +80,7 @@ export function useAuthForm() {
     form.username.trim() &&
     form.password &&
     form.confirmPassword &&
-    Object.keys(errors).length === 0;
+    Object.keys(errors).filter(key => errors[key]).length === 0;
 
   return {
     form,

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
-    "react-native-web": "~0.21.0"
+    "react-native-web": "~0.21.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@types/react": "~19.1.0",

--- a/styles/auth/password-strength-indicator.styles.jsx
+++ b/styles/auth/password-strength-indicator.styles.jsx
@@ -1,0 +1,22 @@
+import { StyleSheet } from 'react-native';
+
+export const styles = StyleSheet.create({
+  container: {
+    marginTop: 8,
+    gap: 4,
+  },
+  barContainer: {
+    height: 4,
+    backgroundColor: 'rgba(0, 0, 0, 0.1)',
+    borderRadius: 2,
+    overflow: 'hidden',
+  },
+  bar: {
+    height: '100%',
+    borderRadius: 2,
+  },
+  label: {
+    fontSize: 12,
+    fontWeight: '600',
+  },
+});

--- a/validators/auth.validators.jsx
+++ b/validators/auth.validators.jsx
@@ -17,9 +17,8 @@ export const registerSchema = z
       .refine((val) => val.trim().length > 0, {
         message: AUTH_ERRORS.EMAIL_REQUIRED,
       })
-      .refine((val) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val.trim()), {
-        message: AUTH_ERRORS.EMAIL_INVALID,
-      }),
+      .transform((val) => val.trim())
+      .pipe(z.email({ message: AUTH_ERRORS.EMAIL_INVALID })),
 
     username: z
       .string()

--- a/validators/auth.validators.jsx
+++ b/validators/auth.validators.jsx
@@ -1,0 +1,74 @@
+import { AUTH_ERRORS } from '@/constants/error.messages.constants';
+import { z } from 'zod';
+
+export const registerSchema = z
+  .object({
+    name: z
+      .string()
+      .refine((val) => val.trim().length > 0, {
+        message: AUTH_ERRORS.NAME_REQUIRED,
+      })
+      .refine((val) => val.trim().length >= 2, {
+        message: AUTH_ERRORS.NAME_MIN_LENGTH,
+      }),
+
+    email: z
+      .string()
+      .refine((val) => val.trim().length > 0, {
+        message: AUTH_ERRORS.EMAIL_REQUIRED,
+      })
+      .refine((val) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(val.trim()), {
+        message: AUTH_ERRORS.EMAIL_INVALID,
+      }),
+
+    username: z
+      .string()
+      .refine((val) => val.trim().length > 0, {
+        message: AUTH_ERRORS.USERNAME_REQUIRED,
+      })
+      .refine((val) => val.trim().length >= 4, {
+        message: AUTH_ERRORS.USERNAME_MIN_LENGTH,
+      })
+      .refine((val) => /^[a-zA-Z0-9_]+$/.test(val.trim()), {
+        message: AUTH_ERRORS.USERNAME_INVALID,
+      }),
+
+    password: z
+      .string()
+      .refine((val) => val.length > 0, {
+        message: AUTH_ERRORS.PASSWORD_REQUIRED,
+      })
+      .refine((val) => val.length >= 8, {
+        message: AUTH_ERRORS.PASSWORD_MIN_LENGTH,
+      })
+      .refine((val) => /[A-Z]/.test(val) && /[a-z]/.test(val) && /[0-9]/.test(val), {
+        message: AUTH_ERRORS.PASSWORD_WEAK,
+      }),
+
+    confirmPassword: z
+      .string()
+      .refine((val) => val.length > 0, {
+        message: AUTH_ERRORS.CONFIRM_PASSWORD_REQUIRED,
+      }),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: AUTH_ERRORS.PASSWORDS_DONT_MATCH,
+    path: ['confirmPassword'],
+  });
+
+export const validateForm = (formData) => {
+  const result = registerSchema.safeParse(formData);
+
+  if (result.success) {
+    return {};
+  }
+
+  const errors = {};
+  result.error.issues.forEach((issue) => {
+    if (issue.path && issue.path.length > 0) {
+      errors[issue.path[0]] = issue.message;
+    }
+  });
+
+  return errors;
+};


### PR DESCRIPTION
## Adiciona validações com Zod e indicador de força de senha

  **Alterações**:
  - Cria constants/error.messages.constants.js com mensagens centralizadas
  - Cria validators/auth.validators.jsx com schema Zod
  - Email validado com z.string().email(), senha com regex (8+ chars, maiúscula/minúscula/número)
  - Nome mínimo 2 caracteres, username mínimo 4 caracteres
  - Mensagens de erro aparecem abaixo dos campos
  - Botão desabilitado até validações passarem
  - Adiciona PasswordStrengthIndicator com zxcvbn mostrando barra colorida (Muito fraca → Muito forte)
  - Erros Firebase apenas no console

  **Como funciona**:
  - registerSchema valida com .refine() e z.email()
  - validateForm() usa .safeParse() retornando erros por campo
  - updateField remove erro ao digitar, reabilita botão
  - Indicador analisa senha em tempo real com zxcvbn (score 0-4)
  
closes #215 