### PR TITLE
feat: implementa conexao com verificaçao de email do firebase e toast

### DIFF
--- a/app/_layout.jsx
+++ b/app/_layout.jsx
@@ -4,9 +4,11 @@ import { Stack } from 'expo-router';
 import * as SplashScreen from 'expo-splash-screen';
 import { useEffect } from 'react';
 import 'react-native-reanimated';
+import Toast from 'react-native-toast-message';
 
 import { ComplaintsProvider } from '@/context/ComplaintsContext';
 import { useColorScheme } from '@/hooks/useColorScheme';
+import { toastConfig } from '@/config/toast.config';
 
 export { ErrorBoundary } from 'expo-router';
 
@@ -50,6 +52,7 @@ function RootLayoutNav() {
           <Stack.Screen name="auth/login" options={{ headerShown: false }} />
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         </Stack>
+        <Toast config={toastConfig} topOffset={60} />
       </ComplaintsProvider>
     </ThemeProvider>
   );

--- a/config/toast.config.jsx
+++ b/config/toast.config.jsx
@@ -1,0 +1,29 @@
+import { View, Text } from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { toastStyles } from '@/styles/toast.styles';
+
+export const toastConfig = {
+  success: ({ text1, text2 }) => (
+    <View style={[toastStyles.container, toastStyles.successBorder]}>
+      <View style={[toastStyles.iconContainer, toastStyles.successIconBg]}>
+        <Ionicons name="checkmark-circle" size={24} color="#10B981" />
+      </View>
+      <View style={toastStyles.textContainer}>
+        <Text style={toastStyles.title}>{text1}</Text>
+        {text2 && <Text style={toastStyles.subtitle}>{text2}</Text>}
+      </View>
+    </View>
+  ),
+
+  error: ({ text1, text2 }) => (
+    <View style={[toastStyles.container, toastStyles.errorBorder]}>
+      <View style={[toastStyles.iconContainer, toastStyles.errorIconBg]}>
+        <Ionicons name="alert-circle" size={24} color="#EF4444" />
+      </View>
+      <View style={toastStyles.textContainer}>
+        <Text style={toastStyles.title}>{text1}</Text>
+        {text2 && <Text style={toastStyles.subtitle}>{text2}</Text>}
+      </View>
+    </View>
+  ),
+};

--- a/hooks/useAuth.jsx
+++ b/hooks/useAuth.jsx
@@ -1,0 +1,66 @@
+import { useState, useEffect } from 'react';
+import { onAuthStateChanged } from 'firebase/auth';
+import { auth } from '@/config/firebase';
+import * as authService from '@/services/auth.service';
+
+export function useAuth() {
+  const [user, setUser] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (firebaseUser) => {
+      setUser(firebaseUser);
+      setLoading(false);
+    });
+
+    return unsubscribe;
+  }, []);
+
+  const register = async (email, password, name, username) => {
+    try {
+      setError(null);
+      setLoading(true);
+      const result = await authService.register(email, password, name, username);
+      return result;
+    } catch (err) {
+      setError(err);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const login = async (emailOrUsername, password) => {
+    try {
+      setError(null);
+      setLoading(true);
+      const result = await authService.login(emailOrUsername, password);
+      return result;
+    } catch (err) {
+      setError(err);
+      throw err;
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const logout = async () => {
+    try {
+      setError(null);
+      await authService.logout();
+    } catch (err) {
+      setError(err);
+      throw err;
+    }
+  };
+
+  return {
+    user,
+    loading,
+    error,
+    register,
+    login,
+    logout,
+  };
+}

--- a/hooks/useAuthForm.jsx
+++ b/hooks/useAuthForm.jsx
@@ -1,11 +1,13 @@
 import { AUTH_ERRORS } from '@/constants/error.messages.constants';
-import { register } from '@/services/auth.service';
 import { validateForm as validateFormSchema } from '@/validators/auth.validators';
 import { router } from 'expo-router';
 import { useState } from 'react';
-import { Alert } from 'react-native';
+import Toast from 'react-native-toast-message';
+import { useAuth } from './useAuth';
 
 export function useAuthForm() {
+  const { register } = useAuth();
+
   const [form, setForm] = useState({
     name: '',
     email: '',
@@ -49,12 +51,15 @@ export function useAuthForm() {
         form.username.trim()
       );
 
-      Alert.alert('Sucesso', 'Conta criada com sucesso!', [
-        {
-          text: 'OK',
-          onPress: () => router.replace('/(tabs)'),
-        },
-      ]);
+      Toast.show({
+        type: 'success',
+        text1: 'Conta criada!',
+        text2: 'Verifique seu email para confirmar',
+      });
+
+      setTimeout(() => {
+        router.replace('/(tabs)');
+      }, 2000);
     } catch (error) {
       let errorMessage = AUTH_ERRORS.GENERIC_ERROR;
 
@@ -69,6 +74,12 @@ export function useAuthForm() {
       }
 
       console.error('Erro ao criar conta:', errorMessage, error);
+
+      Toast.show({
+        type: 'error',
+        text1: 'Erro ao criar conta',
+        text2: errorMessage,
+      });
     } finally {
       setIsSubmitting(false);
     }

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react-native-reanimated": "~4.1.1",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.16.0",
+    "react-native-toast-message": "^2.3.3",
     "react-native-web": "~0.21.0",
     "zod": "^4.3.6",
     "zxcvbn": "^4.4.2"

--- a/services/auth.service.jsx
+++ b/services/auth.service.jsx
@@ -3,6 +3,7 @@ import {
   signInWithEmailAndPassword,
   signOut,
   updateProfile,
+  sendEmailVerification,
 } from 'firebase/auth';
 import { auth, db } from '../config/firebase';
 import { doc, setDoc, getDoc } from 'firebase/firestore';
@@ -42,6 +43,8 @@ export async function register(email, password, name, username) {
     email,
     uid: userCredential.user.uid,
   });
+
+  await sendEmailVerification(userCredential.user);
 
   return userCredential;
 }

--- a/styles/toast.styles.jsx
+++ b/styles/toast.styles.jsx
@@ -1,0 +1,50 @@
+export const toastStyles = {
+  container: {
+    width: '90%',
+    backgroundColor: '#242B3D',
+    borderRadius: 16,
+    padding: 16,
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 4 },
+    shadowOpacity: 0.3,
+    shadowRadius: 8,
+    elevation: 6,
+    borderLeftWidth: 4,
+  },
+  successBorder: {
+    borderLeftColor: '#10B981',
+  },
+  errorBorder: {
+    borderLeftColor: '#EF4444',
+  },
+  iconContainer: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  successIconBg: {
+    backgroundColor: '#10B98120',
+  },
+  errorIconBg: {
+    backgroundColor: '#EF444420',
+  },
+  textContainer: {
+    flex: 1,
+  },
+  title: {
+    fontSize: 16,
+    fontWeight: '700',
+    color: '#FFFFFF',
+    marginBottom: 2,
+  },
+  subtitle: {
+    fontSize: 13,
+    color: '#9CA3AF',
+    lineHeight: 18,
+  },
+};


### PR DESCRIPTION
## implementa hook useAuth com verificação de email e toast customizado

  **Alterações**:

  - Cria hooks/useAuth.jsx com { register, login, logout, user, loading, error }
  - Adiciona sendEmailVerification() no auth.service após criar conta
  - Toast customizado seguindo design do app
  - Traduz erros Firebase (auth/email-already-in-use, auth/weak-password, auth/invalid-email)
  - Cria config/toast.config.jsx e styles/toast.styles.jsx para toasts
  - Redireciona para mapa após registro bem-sucedido (por enquanto, já que não tem tela de login)

  **Como funciona**:

  - useAuth encapsula auth state com onAuthStateChanged observer
  - Email verification enviado automaticamente após registro
  - Toast sucesso: "Conta criada! Verifique seu email para confirmar"
  - Toast erro: apenas para erros do servidor (validação local usa mensagens abaixo dos campos)
  
closes #216 