### PR TITLE
refactor: migra parte do auth para o adminsdk no backend

### DIFF
--- a/hooks/useAuthForm.jsx
+++ b/hooks/useAuthForm.jsx
@@ -63,14 +63,16 @@ export function useAuthForm() {
     } catch (error) {
       let errorMessage = AUTH_ERRORS.GENERIC_ERROR;
 
-      if (error.code === 'auth/email-already-in-use') {
+      if (error.code === 'EMAIL_ALREADY_IN_USE') {
         errorMessage = AUTH_ERRORS.EMAIL_ALREADY_IN_USE;
-      } else if (error.code === 'auth/weak-password') {
-        errorMessage = AUTH_ERRORS.WEAK_PASSWORD;
-      } else if (error.code === 'auth/invalid-email') {
-        errorMessage = AUTH_ERRORS.EMAIL_INVALID;
-      } else if (error.message === 'USERNAME_ALREADY_EXISTS') {
+      } else if (error.code === 'USERNAME_ALREADY_EXISTS') {
         errorMessage = AUTH_ERRORS.USERNAME_ALREADY_EXISTS;
+      } else if (error.code === 'WEAK_PASSWORD') {
+        errorMessage = AUTH_ERRORS.WEAK_PASSWORD;
+      } else if (error.code === 'INVALID_EMAIL') {
+        errorMessage = AUTH_ERRORS.EMAIL_INVALID;
+      } else if (error.message) {
+        errorMessage = error.message;
       }
 
       console.error('Erro ao criar conta:', errorMessage, error);

--- a/services/auth.service.jsx
+++ b/services/auth.service.jsx
@@ -1,48 +1,44 @@
 import {
-  createUserWithEmailAndPassword,
   signInWithEmailAndPassword,
+  signInWithCustomToken,
   signOut,
-  updateProfile,
   sendEmailVerification,
 } from 'firebase/auth';
-import { auth, db } from '../config/firebase';
-import { doc, setDoc, getDoc } from 'firebase/firestore';
+import { auth } from '../config/firebase';
 
-const COLLECTION_PREFIX = process.env.EXPO_PUBLIC_FIREBASE_COLLECTION_PREFIX || '';
-const USERS_COLLECTION = `${COLLECTION_PREFIX}users`;
-const USERNAMES_COLLECTION = `${COLLECTION_PREFIX}usernames`;
+const API_URL = process.env.EXPO_PUBLIC_API_URL;
 
 /**
- * Registra novo usuário com email e senha
+ * Registra novo usuário via backend e autentica
  * @param {string} email - Email do usuário
  * @param {string} password - Senha do usuário
  * @param {string} name - Nome do usuário
  * @param {string} username - Username único (obrigatório)
- * @returns {Promise<UserCredential>} Credenciais do usuário criado
+ * @returns {Promise<UserCredential>} Credenciais do usuário autenticado
  */
 export async function register(email, password, name, username) {
-  const usernameDoc = await getDoc(doc(db, USERNAMES_COLLECTION, username.toLowerCase()));
-  if (usernameDoc.exists()) {
-    throw new Error('USERNAME_ALREADY_EXISTS');
+  const response = await fetch(`${API_URL}/auth/register`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      email,
+      password,
+      name,
+      username,
+    }),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    const error = new Error(data.message || 'Erro ao criar conta');
+    error.code = data.errorCode;
+    throw error;
   }
 
-  const userCredential = await createUserWithEmailAndPassword(auth, email, password);
-
-  await updateProfile(userCredential.user, {
-    displayName: name,
-  });
-
-  await setDoc(doc(db, USERS_COLLECTION, userCredential.user.uid), {
-    email,
-    name,
-    username: username.toLowerCase(),
-    createdAt: new Date().toISOString(),
-  });
-
-  await setDoc(doc(db, USERNAMES_COLLECTION, username.toLowerCase()), {
-    email,
-    uid: userCredential.user.uid,
-  });
+  const userCredential = await signInWithCustomToken(auth, data.data.customToken);
 
   await sendEmailVerification(userCredential.user);
 
@@ -50,24 +46,23 @@ export async function register(email, password, name, username) {
 }
 
 /**
- * Faz login com email/username e senha
- * @param {string} emailOrUsername - Email ou username do usuário
+ * Verifica se username está disponível
+ * @param {string} username - Username para verificar
+ * @returns {Promise<boolean>} True se disponível
+ */
+export async function checkUsername(username) {
+  const response = await fetch(`${API_URL}/auth/check-username/${username}`);
+  const data = await response.json();
+  return data.data.available;
+}
+
+/**
+ * Faz login com email e senha
+ * @param {string} email - Email do usuário
  * @param {string} password - Senha do usuário
  * @returns {Promise<UserCredential>} Credenciais do usuário autenticado
  */
-export async function login(emailOrUsername, password) {
-    let email = emailOrUsername;
-
-  if (!emailOrUsername.includes('@')) {
-    const usernameDoc = await getDoc(doc(db, USERNAMES_COLLECTION, emailOrUsername.toLowerCase()));
-
-    if (!usernameDoc.exists()) {
-      throw new Error('USER_NOT_FOUND');
-    }
-
-    email = usernameDoc.data().email;
-  }
-
+export async function login(email, password) {
   return await signInWithEmailAndPassword(auth, email, password);
 }
 


### PR DESCRIPTION
## Migra autenticação para backend usando Firebase Admin SDK 
 
  **Alterações Frontend (petsos)**:

  - Remove Client SDK direto (getDoc, setDoc, createUserWithEmailAndPassword)
  - auth.service.jsx chama API backend em vez de Firebase direto
  - Autentica com signInWithCustomToken(customToken) após registro
  - Envia email verificação via sendEmailVerification(user)
  - Traduz errorCode do backend para mensagens locais

  **Como funciona**:

  - Backend cria usuário via Admin SDK e retorna customToken (JWT válido 1h)
  - Frontend autentica automaticamente com token (sem pedir senha 2x)
  - Firebase SDK envia email verificação usando templates configurados
  - Validações duplicadas (frontend = UX, backend = segurança)
  - Senha trafega 1x apenas, customToken efêmero para autenticação inicial
  - Firestore Security Rules podem ser mais restritivas (só backend escreve users)
  
closes #261 