### PR TITLE
feat: adiciona botão Assumir e integração com acompanhamento (#232, #…

### DIFF
--- a/app/complaint/[id].jsx
+++ b/app/complaint/[id].jsx
@@ -1,5 +1,5 @@
 import { Stack, useLocalSearchParams, useRouter } from 'expo-router';
-import { useRef } from 'react';
+import { useEffect, useRef } from 'react';
 import { ScrollView, View } from 'react-native';
 
 import { DetailActions } from '@/components/complaints/detail-actions';
@@ -20,6 +20,7 @@ import { useAddress } from '@/hooks/useAddress';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useComplaintConfig } from '@/hooks/useComplaintConfig';
 import { useComplaintDetail } from '@/hooks/useComplaintDetail';
+import { useFollowComplaint } from '@/hooks/useFollowComplaint';
 import Colors from '@/styles/theme/Colors';
 
 export default function ComplaintDetailScreen() {
@@ -45,6 +46,28 @@ export default function ComplaintDetailScreen() {
     handleCloseMapModal,
   } = useComplaintDetail(id);
 
+    const {
+    isFollowing,
+    followComplaint,
+    unfollowComplaint,
+    checkIsFollowing,
+    loading: followLoading,
+  } = useFollowComplaint();
+
+    useEffect(() => {
+      if (id) {
+        checkIsFollowing(id);
+      }
+    }, [id, checkIsFollowing]);
+
+      const handleToggleFollow = () => {
+
+      if (isFollowing) {
+        unfollowComplaint(id);
+      } else {
+        followComplaint(id);
+      }
+    };
   const { address } = useAddress(complaint?.location);
   const { status, type, emoji } = useComplaintConfig(complaint);
 
@@ -72,7 +95,7 @@ export default function ComplaintDetailScreen() {
           status={status}
           type={type}
           emoji={emoji}
-          isHelping={isHelping}
+          isHelping={isFollowing}
           styles={styles}
           colorScheme={colorScheme}
         />
@@ -88,17 +111,18 @@ export default function ComplaintDetailScreen() {
             styles={styles}
           />
           <DetailRegistrarCard complaint={complaint} styles={styles} />
-          <DetailHelpToast isHelping={isHelping} styles={styles} />
+          <DetailHelpToast isHelping={isFollowing} styles={styles} />
         </View>
       </ScrollView>
 
-      <DetailActions 
-        isHelping={isHelping}
-        onToggleHelp={handleToggleHelp}
-        onEdit={handleEdit}
-        onDelete={handleDelete}
-        styles={styles}
-      />
+        <DetailActions
+          isHelping={isFollowing}
+          onToggleHelp={handleToggleFollow}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+          loading={followLoading}
+          styles={styles}
+        />
 
       <DetailMapModal 
         visible={showMapModal}

--- a/components/complaints/detail-actions.jsx
+++ b/components/complaints/detail-actions.jsx
@@ -1,14 +1,21 @@
 import { Pressable, Text, View } from 'react-native';
 
-export function DetailActions({ isHelping, onToggleHelp, onEdit, onDelete, styles }) {
+export function DetailActions({ isHelping, onToggleHelp, onEdit,onDelete,loading,styles
+}) {
   return (
     <View style={styles.detailActionsFixed}>
       <Pressable 
-        style={[styles.detailBtnHelp, isHelping && styles.detailBtnHelping]}
+        style={[styles.detailBtnHelp,isHelping && styles.detailBtnHelping,loading && styles.detailBtnDisabled]}
         onPress={onToggleHelp}
+        disabled={loading}
       >
-        <Text style={styles.detailBtnHelpText}>{isHelping ? 'Ajudando' : 'Ajudar'}</Text>
-        <Text style={{ fontSize: 16 }}>{isHelping ? '✅' : '🤝'}</Text>
+        <Text style={styles.detailBtnHelpText}>
+          {loading ? 'Carregando...' : isHelping ? 'Acompanhando' : 'Assumir'}
+        </Text>
+
+        <Text style={{ fontSize: 16 }}>
+          {isHelping ? '✅' : '🤝'}
+        </Text>
       </Pressable>
 
       <Pressable style={styles.detailBtnEdit} onPress={onEdit}>

--- a/hooks/useFollowComplaint.jsx
+++ b/hooks/useFollowComplaint.jsx
@@ -1,11 +1,12 @@
-import api from "@/services/api";
-import { useCallback, useState } from "react";
+import { assumeComplaint, getFollowers, unfollowComplaint } from '@/services/complaints.service';
+import { useCallback, useState } from 'react';
 
 export function useFollowComplaint() {
   const [isFollowing, setIsFollowing] = useState(false);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
 
+  //  Verifica se o usuário já segue
   const checkIsFollowing = useCallback(async (complaintId) => {
     if (!complaintId) return;
 
@@ -13,56 +14,64 @@ export function useFollowComplaint() {
       setLoading(true);
       setError(null);
 
-      const response = await api.get(`/complaint-followers/${complaintId}`);
+      const response = await getFollowers(complaintId);
 
-      const followers = response.data?.data ?? response.data ?? [];
+      const followers = response?.data ?? [];
 
-      setIsFollowing(followers.length > 0);
+      setIsFollowing(Array.isArray(followers) && followers.length > 0);
     } catch (_err) {
-      setError("Erro ao verificar acompanhamento");
+      setError('Erro ao verificar acompanhamento');
     } finally {
       setLoading(false);
     }
   }, []);
 
+  //  Assumir denúncia
   const followComplaint = useCallback(async (complaintId) => {
-    if (!complaintId) return;
+    if (!complaintId || loading) return;
 
     try {
       setLoading(true);
       setError(null);
 
-      await api.post(`/complaints/${complaintId}/assumir`);
+      await assumeComplaint(complaintId);
 
       setIsFollowing(true);
-    } catch (_err) {
-      setError("Erro ao assumir denúncia");
+    } catch (err) {
+      // trata 409 (já está seguindo)
+      if (err.message?.includes('409')) {
+        setIsFollowing(true);
+        return;
+      }
+
+      setError('Erro ao assumir denúncia');
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [loading]);
 
-  const unfollowComplaint = useCallback(async (complaintId) => {
-    if (!complaintId) return;
+  //  Parar de acompanhar
+  const unfollow = useCallback(async (complaintId) => {
+    if (!complaintId || loading) return;
 
     try {
       setLoading(true);
       setError(null);
 
-      await api.delete(`/complaint-followers/${complaintId}`);
+      await unfollowComplaint(complaintId);
 
       setIsFollowing(false);
     } catch (_err) {
-      setError("Erro ao parar de acompanhar");
+      setError('Erro ao parar de acompanhar');
     } finally {
       setLoading(false);
     }
-  }, []);
+  }, [loading]);
 
   return {
     isFollowing,
     followComplaint,
-    unfollowComplaint,
+    unfollowComplaint: unfollow,
     checkIsFollowing,
     loading,
     error,

--- a/services/complaints.service.jsx
+++ b/services/complaints.service.jsx
@@ -178,3 +178,21 @@ export async function updateComplaint(id, data) {
 export async function getNearbyComplaints(lat, lng, radiusKm = 5) {
   return apiFetch(`/complaints/nearest?lat=${lat}&lng=${lng}&radiusKm=${radiusKm}`);
 }
+
+
+// Função para assumir denuncia 
+export const assumeComplaint = (complaintId) => {
+  return apiFetch(`/complaints/${complaintId}/assumir`, {
+    method: 'POST',
+  });
+};
+
+export const unfollowComplaint = (complaintId) => {
+  return apiFetch(`/complaint-followers/${complaintId}`, {
+    method: 'DELETE',
+  });
+};
+
+export const getFollowers = (complaintId) => {
+  return apiFetch(`/complaint-followers/${complaintId}`);
+};

--- a/styles/complaints/actions.styles.jsx
+++ b/styles/complaints/actions.styles.jsx
@@ -10,6 +10,7 @@ export const actionsStyles = (colorScheme) => {
       flexDirection: 'row',
       gap: 8,
       padding: 14,
+       paddingBottom: 35, //  sobe o botão
       backgroundColor: isDark ? '#000' : '#F7F4F0',
       borderTopWidth: 0.5,
       borderTopColor: isDark ? '#3A3A3A' : '#E8E4DF',


### PR DESCRIPTION
## O que foi feito

- Adicionado botão "Assumir" na tela de detalhes
- Implementado hook useFollowComplaint
- Integração com backend (assumir / deixar de seguir)
- Persistência do estado ao reabrir tela
- Criação de complaints.service

## Rotas utilizadas

- POST /complaints/:id/assumir
- DELETE /complaint-followers/:complaintId
- GET /complaint-followers/:complaintId

## Critérios de aceite

- Botão visível
- Texto dinâmico (Assumir/Acompanhando)
- Desabilitado durante loading
- Estado persistente

closes #232 