### PR TITLE
fix: corrige rota de assumir denúncia no front

### DIFF
--- a/services/complaints.service.jsx
+++ b/services/complaints.service.jsx
@@ -182,7 +182,7 @@ export async function getNearbyComplaints(lat, lng, radiusKm = 5) {
 
 // Função para assumir denuncia 
 export const assumeComplaint = (complaintId) => {
-  return apiFetch(`/complaints/${complaintId}/assumir`, {
+  return apiFetch(`/complaint-followers/${complaintId}/assumir`, {
     method: 'POST',
   });
 };


### PR DESCRIPTION
## Descrição

Corrige a funcionalidade de assumir/acompanhar denúncia no front.

## Alterações realizadas

* Atualiza chamada da função `assumeComplaint`
* Ajusta integração com a rota:

  * `POST /complaint-followers/:complaintId/assumir`
* Corrige mudança de estado do botão "Assumir/Acompanhando"
* Mantém compatibilidade com a nova estrutura de `complaint-followers`

## Testes realizados

* Assumir denúncia funcionando
* Mudança para "Acompanhando" funcionando
* Persistência do acompanhamento validada
* Integração com backend testada via Postman

closes #276
