### PR TITLE
feat: add confirm resolution button

### DIFF
--- a/app/complaint/[id].jsx
+++ b/app/complaint/[id].jsx
@@ -10,6 +10,7 @@ import {
 
 import { CommentComposer } from '@/components/complaints/comment-composer';
 import { CommentsSection } from '@/components/complaints/comments-section';
+import { ConfirmResolutionButton } from '@/components/complaints/confirm-resolution-button';
 import { DetailFollowSummary } from '@/components/complaints/detail-follow-summary';
 import { DetailHero } from '@/components/complaints/detail-hero';
 import { DetailInfoBar } from '@/components/complaints/detail-info-bar';
@@ -17,18 +18,19 @@ import { DetailMainCard } from '@/components/complaints/detail-main-card';
 import { DetailMapCard } from '@/components/complaints/detail-map-card';
 import { DetailMapModal } from '@/components/complaints/detail-map-modal';
 import { DetailPhotosCard } from '@/components/complaints/detail-photos-card';
+import { ErrorState } from '@/components/complaints/error-state';
 import { EvidenceSection } from '@/components/complaints/evidence-section';
 import { EvidenceSubmitModal } from '@/components/complaints/evidence-submit-modal';
 import { EvidenceValidationSection } from '@/components/complaints/evidence-validation-section';
-import { VolunteerButton } from '@/components/complaints/volunteer-button';
-import { ErrorState } from '@/components/complaints/error-state';
-import { LoadingState } from '@/components/complaints/loading-state';
 import { FollowConfirmModal } from '@/components/complaints/follow-confirm-modal';
+import { LoadingState } from '@/components/complaints/loading-state';
 import { UnfollowConfirmModal } from '@/components/complaints/unfollow-confirm-modal';
-import { VolunteerConfirmModal } from '@/components/complaints/volunteer-confirm-modal';
 import { UnvolunteerConfirmModal } from '@/components/complaints/unvolunteer-confirm-modal';
+import { VolunteerButton } from '@/components/complaints/volunteer-button';
+import { VolunteerConfirmModal } from '@/components/complaints/volunteer-confirm-modal';
 import { useAuth } from '@/context/AuthContext';
 import { useAddress } from '@/hooks/useAddress';
+import { useCanConfirmResolution } from '@/hooks/useCanConfirmResolution';
 import { useColorScheme } from '@/hooks/useColorScheme';
 import { useCommentComposerVisibility } from '@/hooks/useCommentComposerVisibility';
 import { useComplaintConfig } from '@/hooks/useComplaintConfig';
@@ -127,6 +129,9 @@ export default function ComplaintDetailScreen() {
   const { address } = useAddress(complaint?.location);
   const { status, type, emoji } = useComplaintConfig(complaint);
   const isOwner = Boolean(user?.uid && user.uid === complaint?.createdById);
+
+  const { canConfirmResolution } = useCanConfirmResolution({ complaintId, complaint, isOwner,});
+ 
   const {
     composerState,
     handleReplyPress,
@@ -256,6 +261,16 @@ export default function ComplaintDetailScreen() {
               refreshEvidence();
             }}
           />
+            {canConfirmResolution && (
+            <ConfirmResolutionButton
+              complaintId={complaintId}
+              onConfirmed={() => {
+                fetchComplaintDetails();
+                refreshEvidence();
+              }}
+              styles={styles}
+            />
+            )}
 
           <CommentsSection
             complaintId={complaintId}

--- a/components/complaints/confirm-resolution-button.jsx
+++ b/components/complaints/confirm-resolution-button.jsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { ActivityIndicator, Alert, Pressable, Text } from 'react-native';
+import Toast from 'react-native-toast-message';
+
+import { confirmComplaintResolution } from '@/services/complaints.service';
+
+export function ConfirmResolutionButton({ complaintId, onConfirmed }) {
+  const [loading, setLoading] = useState(false);
+
+  const handlePress = () => {
+    Alert.alert(
+      'Confirmar resolução',
+      'Tem certeza que deseja marcar como resolvido?',
+      [
+        { text: 'Cancelar', style: 'cancel' },
+        { text: 'Confirmar', onPress: handleConfirm },
+      ],
+    );
+  };
+
+  const handleConfirm = async () => {
+    try {
+      setLoading(true);
+      await confirmComplaintResolution(complaintId);
+
+      Toast.show({
+        type: 'success',
+        text1: 'Denúncia marcada como resolvida',
+      });
+
+      onConfirmed?.();
+    } catch (error) {
+      Toast.show({
+        type: 'error',
+        text1: 'Erro ao marcar denúncia como resolvida',
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <Pressable
+      onPress={handlePress}
+      disabled={loading}
+      style={{
+        marginHorizontal: 30,
+        marginTop: 12,
+        marginBottom: 24,
+        backgroundColor: '#16a34a',
+        borderRadius: 18,
+        paddingVertical: 16,
+        alignItems: 'center',
+        justifyContent: 'center',
+        opacity: loading ? 0.7 : 1,
+        shadowColor: '#000',
+        shadowOpacity: 0.18,
+        shadowRadius: 8,
+        shadowOffset: { width: 0, height: 4 },
+        elevation: 4,
+      }}
+    >
+      {loading ? (
+        <ActivityIndicator color="#fff" />
+      ) : (
+        <Text
+          style={{
+            color: '#fff',
+            fontSize: 16,
+            fontWeight: '800',
+          }}
+        >
+          Marcar como resolvido
+        </Text>
+      )}
+    </Pressable>
+  );
+}

--- a/hooks/useCanConfirmResolution.jsx
+++ b/hooks/useCanConfirmResolution.jsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+import { getComplaintValidationsCount } from '@/services/complaints.service';
+
+const MINIMUM_VALIDATIONS = 3;
+const VALID_STATUSES = ['awaiting_validation', 'aguardando_validacao'];
+
+export function useCanConfirmResolution({ complaintId, complaint, isOwner }) {
+  const [validationsCount, setValidationsCount] = useState(0);
+
+  useEffect(() => {
+    async function loadValidationsCount() {
+      try {
+        const response = await getComplaintValidationsCount(complaintId);
+        setValidationsCount(response?.data?.count ?? 0);
+      } catch (error) {
+        console.log('Erro ao buscar validações', error);
+      }
+    }
+
+    if (complaintId) {
+      loadValidationsCount();
+    }
+  }, [complaintId]);
+
+  const canConfirmResolution =
+    isOwner &&
+    VALID_STATUSES.includes(complaint?.status) &&
+    validationsCount >= MINIMUM_VALIDATIONS;
+
+  return {
+    canConfirmResolution,
+    validationsCount,
+    minimumValidations: MINIMUM_VALIDATIONS,
+  };
+}

--- a/services/complaints.service.jsx
+++ b/services/complaints.service.jsx
@@ -186,3 +186,13 @@ export async function updateComplaintStatus(id, status) {
 export async function getNearbyComplaints(lat, lng, radiusKm = 5) {
   return apiFetch(`/complaints/nearest?lat=${lat}&lng=${lng}&radiusKm=${radiusKm}`);
 }
+
+export async function confirmComplaintResolution(id) {
+  return apiFetch(`/complaints/${id}/confirm-resolution`, {
+    method: 'POST',
+  });
+}
+
+export async function getComplaintValidationsCount(id) {
+  return apiFetch(`/complaints/${id}/validations/count`);
+}


### PR DESCRIPTION
## Descrição

Implementa o componente `ConfirmResolutionButton` na tela de detalhe da denúncia.

### Funcionalidades adicionadas

* Exibição do botão apenas para o autor da denúncia
* Verificação de status `awaiting_validation`
* Verificação de quantidade mínima de validações
* Modal de confirmação antes de concluir ação
* Chamada do endpoint `POST /complaints/:id/confirm-resolution`
* Atualização automática da UI após confirmação
* Toast de sucesso ao marcar denúncia como resolvida
* Remoção do botão após alteração de status

### Melhorias técnicas

* Criação do hook `useCanConfirmResolution`
* Separação da regra de negócio da tela `[id].jsx`
* Integração com endpoint de contagem de validações
* Compatibilidade com múltiplos status de validação

## Como testar

1. Criar denúncia como usuário autenticado
2. Alterar status para `awaiting_validation`
3. Garantir que a denúncia possua pelo menos 3 validações
4. Abrir tela de detalhe como autor da denúncia
5. Verificar exibição do botão "Marcar como resolvido"
6. Confirmar modal
7. Verificar:

   * toast de sucesso
   * atualização do status
   * desaparecimento do botão

## Checklist

* [x] Criar componente `ConfirmResolutionButton`
* [x] Exibir apenas para autor com validações suficientes
* [x] Implementar modal de confirmação
* [x] Chamar endpoint e atualizar UI
* [x] Exibir toast de sucesso
* [x] Remover botão após confirmação

closes #311
