### PR TITLE
feat: add validation counter to complaint details

### DIFF
--- a/app/complaint/[id].jsx
+++ b/app/complaint/[id].jsx
@@ -26,6 +26,7 @@ import { FollowConfirmModal } from '@/components/complaints/follow-confirm-modal
 import { LoadingState } from '@/components/complaints/loading-state';
 import { UnfollowConfirmModal } from '@/components/complaints/unfollow-confirm-modal';
 import { UnvolunteerConfirmModal } from '@/components/complaints/unvolunteer-confirm-modal';
+import { ValidationCounter } from '@/components/complaints/validation-counter';
 import { VolunteerButton } from '@/components/complaints/volunteer-button';
 import { VolunteerConfirmModal } from '@/components/complaints/volunteer-confirm-modal';
 import { useAuth } from '@/context/AuthContext';
@@ -130,7 +131,8 @@ export default function ComplaintDetailScreen() {
   const { status, type, emoji } = useComplaintConfig(complaint);
   const isOwner = Boolean(user?.uid && user.uid === complaint?.createdById);
 
-  const { canConfirmResolution } = useCanConfirmResolution({ complaintId, complaint, isOwner,});
+  
+  const { canConfirmResolution, validationsCount, refreshValidationsCount,} = useCanConfirmResolution({ complaintId, complaint, isOwner });
  
   const {
     composerState,
@@ -168,202 +170,212 @@ export default function ComplaintDetailScreen() {
   if (!complaint) return renderScreenState(null);
 
   return (
-    <View style={styles.detailScreen}>
-      <Stack.Screen options={{ headerShown: false }} />
+  <View style={styles.detailScreen}>
+    <Stack.Screen options={{ headerShown: false }} />
 
-      <KeyboardAvoidingView
-        style={styles.detailKeyboardContainer}
-        behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
-        keyboardVerticalOffset={0}
+    <KeyboardAvoidingView
+      style={styles.detailKeyboardContainer}
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      keyboardVerticalOffset={0}
+    >
+      <ScrollView
+        style={styles.detailScroll}
+        showsVerticalScrollIndicator={false}
+        contentContainerStyle={{
+          paddingBottom: composerVisible && isAuthenticated ? 104 : 18,
+        }}
+        onLayout={handleViewportLayout}
+        onScroll={handleScroll}
+        scrollEventThrottle={16}
       >
-        <ScrollView
-          style={styles.detailScroll}
-          showsVerticalScrollIndicator={false}
-          contentContainerStyle={{
-            paddingBottom: composerVisible && isAuthenticated ? 104 : 18,
-          }}
-          onLayout={handleViewportLayout}
-          onScroll={handleScroll}
-          scrollEventThrottle={16}
-        >
-          <DetailHero
-            complaint={complaint}
-            type={type}
-            emoji={emoji}
-            styles={styles}
-            theme={theme}
-            isOwner={isOwner}
-            onBack={() => router.back()}
-            onEdit={handleEdit}
-            onDelete={handleDelete}
-          />
+        <DetailHero
+          complaint={complaint}
+          type={type}
+          emoji={emoji}
+          styles={styles}
+          theme={theme}
+          isOwner={isOwner}
+          onBack={() => router.back()}
+          onEdit={handleEdit}
+          onDelete={handleDelete}
+        />
 
-          {!isOwner && (
-            <DetailFollowSummary
-              followers={followers}
-              totalFollowers={totalFollowers}
-              followersLoading={followersLoading}
-              followLoading={followLoading}
-              isFollowing={isFollowing}
-              isOwner={isOwner}
-              onToggleFollow={toggleFollow}
-              styles={styles}
-            />
-          )}
-
-          <DetailInfoBar
-            complaint={complaint}
-            status={status}
-            type={type}
-            emoji={emoji}
-            styles={styles}
-            colorScheme={colorScheme}
-          />
-
-          <VolunteerButton
-            complaint={complaint}
-            isOwner={isOwner}
-            isVolunteer={isVolunteer}
-            volunteerLoading={volunteerLoading}
-            onToggleVolunteer={toggleVolunteer}
-            onSubmitEvidence={() => setEvidenceModalVisible(true)}
-            styles={styles}
-          />
-
-          <View style={styles.detailContent}>
-            <DetailMainCard
-              complaint={complaint}
-              address={address}
-              followers={followers}
-              totalFollowers={totalFollowers}
-              followersLoading={followersLoading}
-              showFollowers={isOwner}
-              styles={styles}
-            />
-            <DetailPhotosCard photos={complaint.photos} styles={styles} />
-            <DetailMapCard
-              location={complaint.location}
-              address={address}
-              onOpenMap={() => handleOpenMap(mapRef)}
-              styles={styles}
-            />
-            <EvidenceSection evidences={evidences} styles={styles} />
-          </View>
-
-          <EvidenceValidationSection
-            complaint={complaint}
-            isOwner={isOwner}
-            isVolunteer={isVolunteer}
+        {!isOwner && (
+          <DetailFollowSummary
+            followers={followers}
+            totalFollowers={totalFollowers}
+            followersLoading={followersLoading}
+            followLoading={followLoading}
             isFollowing={isFollowing}
-            evidences={evidences}
-            onStatusChanged={() => {
+            isOwner={isOwner}
+            onToggleFollow={toggleFollow}
+            styles={styles}
+          />
+        )}
+
+        <DetailInfoBar
+          complaint={complaint}
+          status={status}
+          type={type}
+          emoji={emoji}
+          styles={styles}
+          colorScheme={colorScheme}
+        />
+
+        {['awaiting_validation', 'aguardando_validacao', 'resolved', 'resolvido'].includes(complaint.status) && (
+          <ValidationCounter current={validationsCount} />
+        )}
+
+        <VolunteerButton
+          complaint={complaint}
+          isOwner={isOwner}
+          isVolunteer={isVolunteer}
+          volunteerLoading={volunteerLoading}
+          onToggleVolunteer={toggleVolunteer}
+          onSubmitEvidence={() => setEvidenceModalVisible(true)}
+          styles={styles}
+        />
+
+        <View style={styles.detailContent}>
+          <DetailMainCard
+            complaint={complaint}
+            address={address}
+            followers={followers}
+            totalFollowers={totalFollowers}
+            followersLoading={followersLoading}
+            showFollowers={isOwner}
+            styles={styles}
+          />
+
+          <DetailPhotosCard photos={complaint.photos} styles={styles} />
+
+          <DetailMapCard
+            location={complaint.location}
+            address={address}
+            onOpenMap={() => handleOpenMap(mapRef)}
+            styles={styles}
+          />
+
+          <EvidenceSection evidences={evidences} styles={styles} />
+        </View>
+
+        <EvidenceValidationSection
+          complaint={complaint}
+          isOwner={isOwner}
+          isVolunteer={isVolunteer}
+          isFollowing={isFollowing}
+          evidences={evidences}
+          onStatusChanged={() => {
+            fetchComplaintDetails();
+            refreshEvidence();
+            refreshValidationsCount();
+          }}
+        />
+
+        {canConfirmResolution && (
+          <ConfirmResolutionButton
+            complaintId={complaintId}
+            onConfirmed={() => {
               fetchComplaintDetails();
               refreshEvidence();
+              refreshValidationsCount();
             }}
-          />
-            {canConfirmResolution && (
-            <ConfirmResolutionButton
-              complaintId={complaintId}
-              onConfirmed={() => {
-                fetchComplaintDetails();
-                refreshEvidence();
-              }}
-              styles={styles}
-            />
-            )}
-
-          <CommentsSection
-            complaintId={complaintId}
-            comments={comments}
-            totalComments={totalComments}
-            pageInfo={commentsPageInfo}
-            loading={commentsLoading}
-            loadingMore={commentsLoadingMore}
-            isBlocked={commentsBlocked}
-            loadMore={loadMoreComments}
-            toggleLike={toggleLike}
-            incrementRepliesCount={incrementRepliesCount}
-            onReplyPress={handleReplyPress}
-            onSectionLayout={handleSectionLayout}
-            onComposerAnchorLayout={handleComposerAnchorLayout}
             styles={styles}
           />
-        </ScrollView>
-
-        {isAuthenticated && (
-          <Animated.View
-            pointerEvents={composerVisible ? 'auto' : 'none'}
-            style={[styles.detailCommentInputBar, commentComposerAnimatedStyle]}
-          >
-            <CommentComposer
-              key={composerState.key}
-              placeholder={composerState.placeholder}
-              submitting={composerSubmitting}
-              initialText={composerState.initialText}
-              autoFocus={composerState.isReplying}
-              onSubmit={handleComposerSubmit}
-              onFocus={handleInputFocus}
-              onBlur={() => {
-                if (!composerState.isReplying) {
-                  handleInputBlur();
-                }
-              }}
-              styles={styles}
-            />
-          </Animated.View>
         )}
-      </KeyboardAvoidingView>
 
-      <FollowConfirmModal
-        visible={followModalVisible}
-        loading={followLoading}
-        onCancel={closeFollowModal}
-        onConfirm={confirmFollow}
-        styles={styles}
-      />
+        <CommentsSection
+          complaintId={complaintId}
+          comments={comments}
+          totalComments={totalComments}
+          pageInfo={commentsPageInfo}
+          loading={commentsLoading}
+          loadingMore={commentsLoadingMore}
+          isBlocked={commentsBlocked}
+          loadMore={loadMoreComments}
+          toggleLike={toggleLike}
+          incrementRepliesCount={incrementRepliesCount}
+          onReplyPress={handleReplyPress}
+          onSectionLayout={handleSectionLayout}
+          onComposerAnchorLayout={handleComposerAnchorLayout}
+          styles={styles}
+        />
+      </ScrollView>
 
-      <UnfollowConfirmModal
-        visible={unfollowModalVisible}
-        loading={followLoading}
-        onCancel={closeUnfollowModal}
-        onConfirm={confirmUnfollow}
-        styles={styles}
-      />
+      {isAuthenticated && (
+        <Animated.View
+          pointerEvents={composerVisible ? 'auto' : 'none'}
+          style={[styles.detailCommentInputBar, commentComposerAnimatedStyle]}
+        >
+          <CommentComposer
+            key={composerState.key}
+            placeholder={composerState.placeholder}
+            submitting={composerSubmitting}
+            initialText={composerState.initialText}
+            autoFocus={composerState.isReplying}
+            onSubmit={handleComposerSubmit}
+            onFocus={handleInputFocus}
+            onBlur={() => {
+              if (!composerState.isReplying) {
+                handleInputBlur();
+              }
+            }}
+            styles={styles}
+          />
+        </Animated.View>
+      )}
+    </KeyboardAvoidingView>
 
-      <VolunteerConfirmModal
-        visible={volunteerModalVisible}
-        loading={volunteerLoading}
-        onCancel={closeVolunteerModal}
-        onConfirm={confirmVolunteer}
-        styles={styles}
-      />
+    <FollowConfirmModal
+      visible={followModalVisible}
+      loading={followLoading}
+      onCancel={closeFollowModal}
+      onConfirm={confirmFollow}
+      styles={styles}
+    />
 
-      <UnvolunteerConfirmModal
-        visible={unvolunteerModalVisible}
-        loading={volunteerLoading}
-        onCancel={closeUnvolunteerModal}
-        onConfirm={confirmUnvolunteer}
-        styles={styles}
-      />
+    <UnfollowConfirmModal
+      visible={unfollowModalVisible}
+      loading={followLoading}
+      onCancel={closeUnfollowModal}
+      onConfirm={confirmUnfollow}
+      styles={styles}
+    />
 
-      <DetailMapModal
-        visible={showMapModal}
-        location={complaint.location}
-        mapRef={mapRef}
-        onClose={handleCloseMapModal}
-        styles={styles}
-        theme={theme}
-      />
+    <VolunteerConfirmModal
+      visible={volunteerModalVisible}
+      loading={volunteerLoading}
+      onCancel={closeVolunteerModal}
+      onConfirm={confirmVolunteer}
+      styles={styles}
+    />
 
-      <EvidenceSubmitModal
-        visible={evidenceModalVisible}
-        complaintId={complaintId}
-        onClose={() => setEvidenceModalVisible(false)}
-        onSubmitted={() => {
-          fetchComplaintDetails();
-          refreshEvidence();
-        }}
-      />
-    </View>
-  );
+    <UnvolunteerConfirmModal
+      visible={unvolunteerModalVisible}
+      loading={volunteerLoading}
+      onCancel={closeUnvolunteerModal}
+      onConfirm={confirmUnvolunteer}
+      styles={styles}
+    />
+
+    <DetailMapModal
+      visible={showMapModal}
+      location={complaint.location}
+      mapRef={mapRef}
+      onClose={handleCloseMapModal}
+      styles={styles}
+      theme={theme}
+    />
+
+    <EvidenceSubmitModal
+      visible={evidenceModalVisible}
+      complaintId={complaintId}
+      onClose={() => setEvidenceModalVisible(false)}
+      onSubmitted={() => {
+        fetchComplaintDetails();
+        refreshEvidence();
+      }}
+    />
+  </View>
+);
 }

--- a/components/complaints/validation-counter.jsx
+++ b/components/complaints/validation-counter.jsx
@@ -1,0 +1,70 @@
+import { Ionicons } from '@expo/vector-icons';
+import { StyleSheet, Text, View } from 'react-native';
+
+export const MIN_VALIDATIONS = 3;
+
+export function ValidationCounter({ current = 0 }) {
+  const progress = Math.min(current / MIN_VALIDATIONS, 1);
+  const reachedMinimum = current >= MIN_VALIDATIONS;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.header}>
+        <Ionicons
+          name="checkmark-circle"
+          size={20}
+          color={reachedMinimum ? '#10B981' : '#64748B'}
+        />
+
+        <Text style={styles.text}>
+          {current}/{MIN_VALIDATIONS} validações
+        </Text>
+      </View>
+
+      <View style={styles.progressBackground}>
+        <View
+          style={[
+            styles.progressFill,
+            {
+              width: `${progress * 100}%`,
+              backgroundColor: reachedMinimum ? '#10B981' : '#F59E0B',
+            },
+          ]}
+        />
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    marginHorizontal: 16,
+    marginTop: 16,
+    backgroundColor: '#F8FAFC',
+    borderRadius: 12,
+    padding: 14,
+    borderWidth: 1,
+    borderColor: '#E2E8F0',
+  },
+  header: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 8,
+    marginBottom: 10,
+  },
+  text: {
+    fontSize: 14,
+    fontWeight: '700',
+    color: '#334155',
+  },
+  progressBackground: {
+    height: 8,
+    borderRadius: 999,
+    backgroundColor: '#E2E8F0',
+    overflow: 'hidden',
+  },
+  progressFill: {
+    height: '100%',
+    borderRadius: 999,
+  },
+});

--- a/hooks/useCanConfirmResolution.jsx
+++ b/hooks/useCanConfirmResolution.jsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
 import { getComplaintValidationsCount } from '@/services/complaints.service';
 
@@ -8,20 +8,20 @@ const VALID_STATUSES = ['awaiting_validation', 'aguardando_validacao'];
 export function useCanConfirmResolution({ complaintId, complaint, isOwner }) {
   const [validationsCount, setValidationsCount] = useState(0);
 
-  useEffect(() => {
-    async function loadValidationsCount() {
-      try {
-        const response = await getComplaintValidationsCount(complaintId);
-        setValidationsCount(response?.data?.count ?? 0);
-      } catch (error) {
-        console.log('Erro ao buscar validações', error);
-      }
+  const loadValidationsCount = useCallback(async () => {
+    try {
+      const response = await getComplaintValidationsCount(complaintId);
+      setValidationsCount(response?.data?.count ?? 0);
+    } catch (error) {
+      console.log('Erro ao buscar validações', error);
     }
+  }, [complaintId]);
 
+  useEffect(() => {
     if (complaintId) {
       loadValidationsCount();
     }
-  }, [complaintId]);
+  }, [complaintId, loadValidationsCount]);
 
   const canConfirmResolution =
     isOwner &&
@@ -32,5 +32,6 @@ export function useCanConfirmResolution({ complaintId, complaint, isOwner }) {
     canConfirmResolution,
     validationsCount,
     minimumValidations: MINIMUM_VALIDATIONS,
+    refreshValidationsCount: loadValidationsCount,
   };
 }


### PR DESCRIPTION
## Descrição

Implementa componente `ValidationCounter` na tela de detalhe da denúncia.

### O que foi feito

* Criado componente `ValidationCounter`
* Exibição da quantidade de validações
* Adicionada barra de progresso visual
* Integração na tela de detalhe da denúncia
* Atualização automática da contagem após validação
* Exibição condicionada pelos status da denúncia

### Regras implementadas

* Exibe formato `X/3 validações`
* Barra de progresso proporcional à quantidade de validações
* Barra fica verde ao atingir o mínimo
* Componente visível apenas nos status:

  * `awaiting_validation`
  * `aguardando_validacao`
  * `resolved`
  * `resolvido`

### Observações

Mantido mínimo de 3 validações para compatibilidade com a regra atual do backend e fluxo existente da aplicação.

## Checklist

* [x] Criar componente `ValidationCounter`
* [x] Exibir ícone + número de validações
* [x] Criar barra de progresso visual
* [x] Integrar na tela de detalhe
* [x] Atualização automática após validação
* [x] Ocultar nos status `pending` e `in_progress`

closes #308
